### PR TITLE
Look for iam_apikey in credential file for IAM auth

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Service/IBMService.cs
+++ b/src/IBM.Cloud.SDK.Core/Service/IBMService.cs
@@ -105,6 +105,10 @@ namespace IBM.Cloud.SDK.Core.Service
                 }
 
                 string apiKey = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_IAM_APIKEY");
+                // check for old IAM API key name as well
+                if (string.IsNullOrEmpty(apiKey)) {
+                    apiKey = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_APIKEY");
+                }
                 if (!string.IsNullOrEmpty(apiKey))
                     ApiKey = apiKey;
                 string un = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_USERNAME");

--- a/src/IBM.Cloud.SDK.Core/Service/IBMService.cs
+++ b/src/IBM.Cloud.SDK.Core/Service/IBMService.cs
@@ -104,7 +104,7 @@ namespace IBM.Cloud.SDK.Core.Service
                     }
                 }
 
-                string apiKey = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_APIKEY");
+                string apiKey = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_IAM_APIKEY");
                 if (!string.IsNullOrEmpty(apiKey))
                     ApiKey = apiKey;
                 string un = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_USERNAME");


### PR DESCRIPTION
Related to an internal naming debate. Basically, we've decided we should be using `iam_apikey` for IAM keys and are updating code on the IBM Cloud side to adhere to this. This will then require updating on the SDK side to capture those changes.

In this PR, we still do look for the old `apikey` name so as not to break anyone who may have been using an old credential file.