### PR TITLE
Parse floats to strings with invariant culture

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Util/Utility.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/Utility.cs
@@ -201,5 +201,10 @@ namespace IBM.Cloud.SDK.Core.Util
 
             return "unknown error";
         }
+
+        public static string ParseCultureInvariantFloatToString(float value)
+        {
+            return value.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+        }
     }
 }

--- a/test/IBM.Cloud.SDK.Core.Tests/UtilTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/UtilTests.cs
@@ -20,6 +20,7 @@ using IBM.Cloud.SDK.Core.Util;
 using System.Collections.Generic;
 using System.IO;
 using System;
+using System.Globalization;
 
 namespace IBM.Cloud.SDK.Core.Tests.Util
 {
@@ -204,6 +205,23 @@ namespace IBM.Cloud.SDK.Core.Tests.Util
             string json = "{\"msg\": \":(\"}";
             string errorMessage = Utility.GetErrorMessage(json);
             Assert.IsTrue(errorMessage == "unknown error");
+        }
+
+        [TestMethod]
+        public void GetCultureInvariantFloat()
+        {
+
+            var previousCulture = CultureInfo.CurrentCulture;
+
+            CultureInfo.CurrentCulture = new CultureInfo("pt-BR");
+            float value;
+            bool b = float.TryParse("1,23", NumberStyles.Any, new CultureInfo("pt-BR"), out value);
+
+            string numString = Utility.ParseCultureInvariantFloatToString(value);
+            Assert.IsNotNull(numString);
+            Assert.IsTrue(numString == "1.23");
+
+            CultureInfo.CurrentCulture = previousCulture;
         }
     }
 }

--- a/test/IBM.Cloud.SDK.Core.Tests/UtilTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/UtilTests.cs
@@ -210,7 +210,6 @@ namespace IBM.Cloud.SDK.Core.Tests.Util
         [TestMethod]
         public void GetCultureInvariantFloat()
         {
-
             var previousCulture = CultureInfo.CurrentCulture;
 
             CultureInfo.CurrentCulture = new CultureInfo("pt-BR");


### PR DESCRIPTION
This pull request adds a utility method to parse floats into strings with invariant culture. We will use this utility method in the generator whenever adding a float value to a query param.

Related issues
https://github.com/watson-developer-cloud/dotnet-standard-sdk/issues/312
https://github.com/watson-developer-cloud/dotnet-standard-sdk/pull/340
https://github.ibm.com/Watson/developer-experience/issues/6438