### PR TITLE
Fix update response

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Http/Request.cs
+++ b/src/IBM.Cloud.SDK.Core/Http/Request.cs
@@ -133,7 +133,10 @@ namespace IBM.Cloud.SDK.Core.Http
             detailedResponse.StatusCode = (long)message.StatusCode;
 
             //  Set response
-            detailedResponse.Response = JValue.Parse(result).ToString(Formatting.Indented);
+            if (!string.IsNullOrEmpty(result))
+            {
+                detailedResponse.Response = JValue.Parse(result).ToString(Formatting.Indented);
+            }
 
             //  Set result
             detailedResponse.Result = await message.Content.ReadAsAsync<T>(this.Formatters).ConfigureAwait(false);

--- a/src/IBM.Cloud.SDK.Core/Http/Request.cs
+++ b/src/IBM.Cloud.SDK.Core/Http/Request.cs
@@ -130,8 +130,7 @@ namespace IBM.Cloud.SDK.Core.Http
                 detailedResponse.Headers.Add(header.Key, string.Join(",", header.Value));
 
             //  Set staus code
-            long.TryParse(message.StatusCode.ToString(), out long statusCode);
-            detailedResponse.StatusCode = statusCode;
+            detailedResponse.StatusCode = (long)message.StatusCode;
 
             //  Set response
             detailedResponse.Response = JValue.Parse(result).ToString(Formatting.Indented);


### PR DESCRIPTION
This pull request removes string parsing of status code to long. Since the `StatusCode.ToString()` method results in the string description of the status code (ie "NO CONTENT") instead of a string "204", the status code would not parse into a long value.

Additionally a null check was added before attempting to parse the result since the result may not have a value.