### PR TITLE
Add null check for tokenResponse when saving tokeninfo

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Util/TokenManager.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/TokenManager.cs
@@ -225,7 +225,10 @@ namespace IBM.Cloud.SDK.Core.Util
         /// <param name="tokenResponse"></param>
         private void SaveTokenInfo(IamTokenData tokenResponse)
         {
-            _tokenInfo = tokenResponse;
+            if (tokenResponse != null)
+            {
+                _tokenInfo = tokenResponse;
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request adds a null check for tokenResponse before saving token info. 