### PR TITLE
Clear default accept headers on instantiation

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Http/Request.cs
+++ b/src/IBM.Cloud.SDK.Core/Http/Request.cs
@@ -49,6 +49,7 @@ namespace IBM.Cloud.SDK.Core.Http
             this.Formatters = formatters;
             this.Dispatch = new Lazy<Task<HttpResponseMessage>>(() => dispatcher(this));
             this.Filters = filters;
+            this.Message.Headers.Accept.Clear();
         }
         
         public IRequest WithBody<T>(T body, MediaTypeHeaderValue contentType = null)
@@ -71,10 +72,6 @@ namespace IBM.Cloud.SDK.Core.Http
 
         public IRequest WithHeader(string key, string value)
         {
-            if (key == "Accept" && value.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
-            {
-                this.Message.Headers.Accept.Clear();
-            }
             this.Message.Headers.TryAddWithoutValidation(key, value);
             return this;
         }


### PR DESCRIPTION
The http library for .NET has default accept headers. We were clearing these for TTS but this also caused issues in Personality Insights ProfileAsCSV operation. This pull request clears the default headers on instantiation.