### PR TITLE
Refactor default IAM URL

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Util/Credentials.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/Credentials.cs
@@ -140,8 +140,9 @@ namespace IBM.Cloud.SDK.Core.Util
                 }
             }
         }
+
         /// <summary>
-        /// The IAM authentication URL. If omitted the value defaults to "https://iam.bluemix.net/identity/token".
+        /// The IAM authentication URL. If omitted the value defaults to "https://iam.cloud.ibm.com/identity/token".
         /// </summary>
         public string IamUrl { get; set; }
     }

--- a/src/IBM.Cloud.SDK.Core/Util/TokenManager.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/TokenManager.cs
@@ -33,7 +33,7 @@ namespace IBM.Cloud.SDK.Core.Util
 
         public TokenManager(TokenOptions options)
         {
-            _iamUrl = !string.IsNullOrEmpty(options.IamUrl) ? options.IamUrl : "https://iam.bluemix.net/identity/token";
+            _iamUrl = !string.IsNullOrEmpty(options.IamUrl) ? options.IamUrl : "https://iam.cloud.ibm.com/identity/token";
             _tokenInfo = new IamTokenData();
             if (!string.IsNullOrEmpty(options.IamApiKey))
                 _iamApikey = options.IamApiKey;


### PR DESCRIPTION
This pull request refactors the default IAM URL to `https://iam.cloud.ibm.com/identity/token`