### PR TITLE
Remove escape query params

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Http/Extensions/UriExtensions.cs
+++ b/src/IBM.Cloud.SDK.Core/Http/Extensions/UriExtensions.cs
@@ -34,7 +34,7 @@ namespace IBM.Cloud.SDK.Core.Http.Extensions
                                     WebUtility.UrlEncode(argument.Value.ToString().ToLower()) : 
                                         WebUtility.UrlEncode(argument.Value.ToString()) : 
                                             string.Empty
-                select key + "=" + Uri.EscapeDataString(value)
+                select key + "=" + value
             );
             return new Uri(
                 uri

--- a/test/IBM.Cloud.SDK.Core.Tests/HttpTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/HttpTests.cs
@@ -33,7 +33,7 @@ namespace IBM.Cloud.SDK.Core.Tests
 
             restRequest.WithArgument("myArg", "Is this a valid arg?");
 
-            Assert.IsTrue(restRequest.Message.RequestUri == new Uri("http://baseuri.com/v1/operation?myArg=Is%2Bthis%2Ba%2Bvalid%2Barg%253F"));
+            Assert.IsTrue(restRequest.Message.RequestUri == new Uri("http://baseuri.com/v1/operation?myArg=Is+this+a+valid+arg%3F"));
         }
     }
 }


### PR DESCRIPTION
Query params were already being escaped a few lines up. This pull request reverts the last commit.