### PR TITLE
Look for config file in working directory before the home directory

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
@@ -132,6 +132,15 @@ namespace IBM.Cloud.SDK.Core.Util
             {
                 files.Add(userSpecifedPath);
             }
+            
+            if (!string.IsNullOrEmpty(projectDirectory))
+            {
+                var fullPath = Path.GetFullPath(Path.Combine(projectDirectory, defaultCredentialFileName));
+                if (File.Exists(fullPath))
+                {
+                    files.Add(fullPath);
+                }
+            }
 
             if (!string.IsNullOrEmpty(unixHomeDirectory))
             {
@@ -154,15 +163,6 @@ namespace IBM.Cloud.SDK.Core.Util
             if (!string.IsNullOrEmpty(windowsSecondHomeDirectory))
             {
                 var fullPath = Path.GetFullPath(Path.Combine(windowsSecondHomeDirectory, defaultCredentialFileName));
-                if (File.Exists(fullPath))
-                {
-                    files.Add(fullPath);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(projectDirectory))
-            {
-                var fullPath = Path.GetFullPath(Path.Combine(projectDirectory, defaultCredentialFileName));
                 if (File.Exists(fullPath))
                 {
                     files.Add(fullPath);

--- a/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
@@ -118,10 +118,8 @@ namespace IBM.Cloud.SDK.Core.Util
         /// Top-level directory of the project this code is being called in
         /// </summary>
         /// <returns>List of credential files to check</returns>
-        private static List<string> GetFilesToCheck()
+        private static string GetFileToCheck()
         {
-            List<string> files = new List<string>();
-
             string userSpecifedPath = Environment.GetEnvironmentVariable("IBM_CREDENTIALS_FILE");
             string unixHomeDirectory = Environment.GetEnvironmentVariable("HOME");
             string windowsFirstHomeDirectory = Environment.GetEnvironmentVariable("HOMEDRIVE") + Environment.GetEnvironmentVariable("HOMEPATH");
@@ -130,15 +128,15 @@ namespace IBM.Cloud.SDK.Core.Util
 
             if (!string.IsNullOrEmpty(userSpecifedPath) && File.Exists(userSpecifedPath))
             {
-                files.Add(userSpecifedPath);
+                return userSpecifedPath;
             }
-            
+
             if (!string.IsNullOrEmpty(projectDirectory))
             {
                 var fullPath = Path.GetFullPath(Path.Combine(projectDirectory, defaultCredentialFileName));
                 if (File.Exists(fullPath))
                 {
-                    files.Add(fullPath);
+                    return fullPath;
                 }
             }
 
@@ -147,7 +145,7 @@ namespace IBM.Cloud.SDK.Core.Util
                 var fullPath = Path.GetFullPath(Path.Combine(unixHomeDirectory, defaultCredentialFileName));
                 if (File.Exists(fullPath))
                 {
-                    files.Add(fullPath);
+                    return fullPath;
                 }
             }
 
@@ -156,7 +154,7 @@ namespace IBM.Cloud.SDK.Core.Util
                 var fullPath = Path.GetFullPath(Path.Combine(windowsFirstHomeDirectory, defaultCredentialFileName));
                 if (File.Exists(fullPath))
                 {
-                    files.Add(fullPath);
+                    return fullPath;
                 }
             }
 
@@ -165,11 +163,11 @@ namespace IBM.Cloud.SDK.Core.Util
                 var fullPath = Path.GetFullPath(Path.Combine(windowsSecondHomeDirectory, defaultCredentialFileName));
                 if (File.Exists(fullPath))
                 {
-                    files.Add(fullPath);
+                    return fullPath;
                 }
             }
 
-            return files;
+            return null;
         }
 
         /// <summary>
@@ -177,17 +175,16 @@ namespace IBM.Cloud.SDK.Core.Util
         /// </summary>
         /// <param name="files"></param>
         /// <returns>list of lines in the credential file, or null if no file is found</returns>
-        private static List<string> GetFirstExistingFileContents(List<string> files)
+        private static List<string> GetFileContents(string file)
         {
+            if (string.IsNullOrEmpty(file))
+                return null;
+
             List<string> credentialFileContents = null;
             try
             {
-                foreach (string file in files)
-                {
-                    var contentsArray = File.ReadAllLines(file);
-                    credentialFileContents = new List<string>(contentsArray);
-                    break;
-                }
+                var contentsArray = File.ReadAllLines(file);
+                credentialFileContents = new List<string>(contentsArray);
             }
             catch (IOException e)
             {
@@ -199,8 +196,8 @@ namespace IBM.Cloud.SDK.Core.Util
 
         public static Dictionary<string, string> GetFileCredentialsAsMap(string serviceName)
         {
-            List<string> files = GetFilesToCheck();
-            List<string> contents = GetFirstExistingFileContents(files);
+            string file = GetFileToCheck();
+            List<string> contents = GetFileContents(file);
             if (contents != null && contents.Count > 0)
             {
                 return ParseCredentials(serviceName, contents);

--- a/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
@@ -124,16 +124,16 @@ namespace IBM.Cloud.SDK.Core.Util
             string unixHomeDirectory = Environment.GetEnvironmentVariable("HOME");
             string windowsFirstHomeDirectory = Environment.GetEnvironmentVariable("HOMEDRIVE") + Environment.GetEnvironmentVariable("HOMEPATH");
             string windowsSecondHomeDirectory = Environment.GetEnvironmentVariable("USERPROFILE");
-            string projectDirectory = Directory.GetCurrentDirectory();
+            string currentDirectory = Directory.GetCurrentDirectory();
 
             if (!string.IsNullOrEmpty(userSpecifedPath) && File.Exists(userSpecifedPath))
             {
                 return userSpecifedPath;
             }
 
-            if (!string.IsNullOrEmpty(projectDirectory))
+            if (!string.IsNullOrEmpty(currentDirectory))
             {
-                var fullPath = Path.GetFullPath(Path.Combine(projectDirectory, defaultCredentialFileName));
+                var fullPath = Path.GetFullPath(Path.Combine(currentDirectory, defaultCredentialFileName));
                 if (File.Exists(fullPath))
                 {
                     return fullPath;

--- a/test/IBM.Cloud.SDK.Core.Tests/ConfigBasedAuthenticatorFactoryTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/ConfigBasedAuthenticatorFactoryTests.cs
@@ -119,7 +119,7 @@ namespace IBM.Cloud.SDK.Core.Tests.ConfigBasedAuthenticatorFactoryTests
                 Assert.Fail(string.Format("Unexpected exception of type {0} caught: {1}", e.GetType(), e.Message));
             }
 
-            Environment.SetEnvironmentVariable("TEST_SERVICE_AUTH_TYPE", null); 
+            Environment.SetEnvironmentVariable("TEST_SERVICE_AUTH_TYPE", null);
         }
     }
 }

--- a/test/IBM.Cloud.SDK.Core.Tests/CredentialUtilsTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/CredentialUtilsTests.cs
@@ -162,7 +162,7 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
 
             using (StreamWriter outputFile = new StreamWriter(docPath))
             {
-                foreach(string line in lines)
+                foreach (string line in lines)
                 {
                     outputFile.WriteLine(line);
                 }
@@ -177,7 +177,7 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
             Assert.IsTrue(props.ContainsKey("LOCATION"));
             props.TryGetValue("LOCATION", out string envLocation);
             Assert.IsTrue(envLocation == "user-set-location");
-            
+
             //  delete created env files
             if (File.Exists(docPath))
             {

--- a/test/IBM.Cloud.SDK.Core.Tests/CredentialUtilsTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/CredentialUtilsTests.cs
@@ -125,11 +125,72 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
         }
 
         [TestMethod]
-        public void TestConvertToUtf8()
+        public void TestCredentialOrder()
         {
-            var testString = "testString¼";
-            var utf8String = Utility.ConvertToUtf8(testString);
-            Assert.IsTrue(!string.IsNullOrEmpty(utf8String));
+            // store and clear user set env variable
+            string ibmCredFile = Environment.GetEnvironmentVariable("IBM_CREDENTIALS_FILE");
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", "");
+
+            //  create .env file in current directory
+            string[] linesWorking = { "TEST_SERVICE_LOCATION=working-directory" };
+            var directoryPathWorking = Directory.GetCurrentDirectory();
+            var docPathWorking = Path.Combine(directoryPathWorking, "ibm-credentials.env");
+
+            using (StreamWriter outputFile = new StreamWriter(docPathWorking))
+            {
+                foreach (string line in linesWorking)
+                {
+                    outputFile.WriteLine(line);
+                }
+            }
+
+            //  get props
+            Dictionary<string, string> propsWorking = CredentialUtils.GetFileCredentialsAsMap("test_service");
+
+            Assert.IsTrue(propsWorking.ContainsKey("LOCATION"));
+            propsWorking.TryGetValue("LOCATION", out string envWorkingLocation);
+            Assert.IsTrue(envWorkingLocation == "working-directory");
+
+            //  create .env file in user set directory
+            string[] lines = { "TEST_SERVICE_LOCATION=user-set-location" };
+
+            var directoryPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.CommonApplicationData
+                );
+
+            var docPath = Path.Combine(directoryPath, "test-credentials.env");
+
+            using (StreamWriter outputFile = new StreamWriter(docPath))
+            {
+                foreach(string line in lines)
+                {
+                    outputFile.WriteLine(line);
+                }
+            }
+
+            //  set user set env file path variable
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", docPath);
+
+            //  get props
+            Dictionary<string, string> props = CredentialUtils.GetFileCredentialsAsMap("test_service");
+
+            Assert.IsTrue(props.ContainsKey("LOCATION"));
+            props.TryGetValue("LOCATION", out string envLocation);
+            Assert.IsTrue(envLocation == "user-set-location");
+            
+            //  delete created env files
+            if (File.Exists(docPath))
+            {
+                File.Delete(docPath);
+            }
+
+            if (File.Exists(docPathWorking))
+            {
+                File.Delete(docPathWorking);
+            }
+
+            //  reset env variable
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", ibmCredFile);
         }
     }
 }

--- a/test/IBM.Cloud.SDK.Core.Tests/UtilTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/UtilTests.cs
@@ -181,5 +181,13 @@ namespace IBM.Cloud.SDK.Core.Tests.Util
 
             CultureInfo.CurrentCulture = previousCulture;
         }
+
+        [TestMethod]
+        public void TestConvertToUtf8()
+        {
+            var testString = "testString¼";
+            var utf8String = Utility.ConvertToUtf8(testString);
+            Assert.IsTrue(!string.IsNullOrEmpty(utf8String));
+        }
     }
 }


### PR DESCRIPTION
This pull request changes the order of where the SDK looks for external credentials. The SDK now looks for credentials in the project directory before looking in the home directory.

BREAKING CHANGE: SDK now looks for the config file in the working directory before looking in the
home directory