### PR TITLE
Avoid multiple auth calls

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Authentication/Iam/IamToken.cs
+++ b/src/IBM.Cloud.SDK.Core/Authentication/Iam/IamToken.cs
@@ -23,6 +23,7 @@ namespace IBM.Cloud.SDK.Core.Authentication.Iam
     {
         public string AccessToken { get; set; }
         public long ExpirationTimeInMillis { get; set; }
+        public long ExpirationTime { get; set; }
 
         /// <summary>
         /// This ctor is used to store a user-managed access token which will never expire.
@@ -43,12 +44,13 @@ namespace IBM.Cloud.SDK.Core.Authentication.Iam
             long? expireTime = response.Expiration;
             long currentTime = DateTimeOffset.Now.ToUnixTimeSeconds();
 
-            ExpirationTimeInMillis = (long)expireTime - ((long)timeToLive * (long)(1.0 - fractionOfTtl)) * 1000;
+            ExpirationTime = (long)(currentTime + (timeToLive * fractionOfTtl));
+            ExpirationTimeInMillis = ExpirationTime * 1000;
         }
 
         public bool IsTokenValid()
         {
-            return !string.IsNullOrEmpty(AccessToken) && (ExpirationTimeInMillis < 0 || DateTimeOffset.Now.ToUnixTimeMilliseconds() <= ExpirationTimeInMillis);
+            return DateTimeOffset.Now.ToUnixTimeSeconds() < ExpirationTime;
         }
     }
 }

--- a/src/IBM.Cloud.SDK.Core/IBM.Cloud.SDK.Core.csproj
+++ b/src/IBM.Cloud.SDK.Core/IBM.Cloud.SDK.Core.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.1.0-rc01</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/IBM.Cloud.SDK.Core/IBM.Cloud.SDK.Core.csproj
+++ b/src/IBM.Cloud.SDK.Core/IBM.Cloud.SDK.Core.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.0.0</Version>
+    <Version>1.1.0-rc01</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This pull request addresses an issue where a client was seeing calls to get iam token on each service call. This boiled down to comparing time in seconds vs milliseconds.