### PR TITLE
fix: allow '=' character in environment config values

### DIFF
--- a/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
+++ b/src/IBM.Cloud.SDK.Core/Util/CredentialUtils.cs
@@ -340,7 +340,7 @@ namespace IBM.Cloud.SDK.Core.Util
                 }
 
                 string[] stringSeparators = new string[] { "=" };
-                List<string> lineTokens = new List<string>(line.Split(stringSeparators, StringSplitOptions.None));
+                List<string> lineTokens = new List<string>(line.Split(stringSeparators, 2, StringSplitOptions.None));
                 if (lineTokens.Count != 2)
                 {
                     continue;

--- a/test/IBM.Cloud.SDK.Core.Tests/CredentialUtilsTests.cs
+++ b/test/IBM.Cloud.SDK.Core.Tests/CredentialUtilsTests.cs
@@ -59,6 +59,49 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
         }
 
         [TestMethod]
+        public void TestGetFileCredentialsAsMapService1()
+        {
+            // store and clear user set env variable
+            string ibmCredFile = Environment.GetEnvironmentVariable("IBM_CREDENTIALS_FILE");
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", "");
+
+            //  create .env file in current directory
+            string[] linesWorking = { "SERVICE_1_AUTH_TYPE=iam",
+                                      "SERVICE_1_APIKEY=V4HXmoUtMjohnsnow=KotN",
+                                      "SERVICE_1_CLIENT_ID=somefake========id",
+                                      "SERVICE_1_CLIENT_SECRET===my-client-secret==",
+                                      "SERVICE_1_AUTH_URL=https://iamhost/iam/api=",
+                                      "SERVICE_1_AUTH_DISABLE_SSL=" };
+            var directoryPath = Directory.GetCurrentDirectory();
+            var credsFile = Path.Combine(directoryPath, "ibm-credentials.env");
+
+            using (StreamWriter outputFile = new StreamWriter(credsFile))
+            {
+                foreach (string line in linesWorking)
+                {
+                    outputFile.WriteLine(line);
+                }
+            }
+
+            //  get props
+            Dictionary<string, string> propsWorking = CredentialUtils.GetFileCredentialsAsMap("service_1");
+            Assert.IsNotNull(propsWorking);
+            Assert.AreEqual(propsWorking["AUTH_TYPE"], "iam");
+            Assert.AreEqual(propsWorking["APIKEY"], "V4HXmoUtMjohnsnow=KotN");
+            Assert.AreEqual(propsWorking["CLIENT_ID"], "somefake========id");
+            Assert.AreEqual(propsWorking["CLIENT_SECRET"], "==my-client-secret==");
+            Assert.AreEqual(propsWorking["AUTH_URL"], "https://iamhost/iam/api=");
+            Assert.IsFalse(propsWorking.ContainsKey("DISABLE_SSL"));
+            //  delete created env files
+            if (File.Exists(credsFile))
+            {
+                File.Delete(credsFile);
+            }
+            //  reset env variable
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", ibmCredFile);
+        }
+
+        [TestMethod]
         public void TestGetEnvCredentialsAsMap()
         {
             var apikey = "bogus-apikey";
@@ -76,9 +119,61 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
         }
 
         [TestMethod]
+        public void TestGetEnvCredentialsAsMapService1()
+        {
+            var apikey = "V4HXmoUtMjohnsnow=KotN";
+            var authType = "iam";
+            var clientId = "somefake========id";
+            var clientIdSecret = "==my-client-secret==";
+            var authUrl = "https://iamhost/iam/api=";
+
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameApikey,
+                apikey);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameAuthType,
+                authType);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientId,
+                clientId);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientSecret,
+                clientIdSecret);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameUrl,
+                authUrl);
+            // get props
+            Dictionary<string, string> props = CredentialUtils.GetEnvCredentialsAsMap("service_1");
+            Assert.IsNotNull(props);
+            Assert.AreEqual(props["AUTH_TYPE"], authType);
+            Assert.AreEqual(props["APIKEY"], apikey);
+            Assert.AreEqual(props["CLIENT_ID"], clientId);
+            Assert.AreEqual(props["CLIENT_SECRET"], clientIdSecret);
+            Assert.AreEqual(props["AUTH_URL"], authUrl);
+
+            //  delete created env files
+             Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameApikey,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameAuthType,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientId,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientSecret,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameUrl,
+                null);
+        }
+
+        [TestMethod]
         public void TestGetVcapCredentialsAsMap()
         {
             var apikey = "bogus-apikey";
+            var service1_apikey = "V4HXmoUtMjohnsnow=KotN";
             var tempVcapCredential = new Dictionary<string, List<VcapCredential>>();
             var vcapCredential = new VcapCredential()
             {
@@ -87,7 +182,18 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
                     ApiKey = apikey
                 }
             };
+
+            var vcapCredential2 = new VcapCredential()
+            {
+                Credentials = new Credential()
+                {
+                    ApiKey = service1_apikey
+                }
+            };
+            vcapCredential2.Name = "equals_sign_test";
+
             tempVcapCredential.Add("assistant", new List<VcapCredential>() { vcapCredential });
+            tempVcapCredential.Add("equals_sign_test", new List<VcapCredential>() { vcapCredential2 });
 
             var vcapString = JsonConvert.SerializeObject(tempVcapCredential);
             Environment.SetEnvironmentVariable("VCAP_SERVICES", vcapString);
@@ -99,6 +205,15 @@ namespace IBM.Cloud.SDK.Core.Tests.CredentialUtilsTests
                 Authenticator.PropNameApikey,
                 out string extractedKey);
             Assert.IsTrue(extractedKey == apikey);
+
+            vcapCredentaialsAsMap = CredentialUtils.GetVcapCredentialsAsMap("equals_sign_test");
+            Assert.IsNotNull(vcapCredentaialsAsMap);
+            vcapCredentaialsAsMap.TryGetValue(
+                Authenticator.PropNameApikey,
+                out string extractedKey2);
+            Assert.IsTrue(extractedKey2 == service1_apikey);
+
+
         }
 
         [TestMethod]


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1759

Changes:
- allow for a env config property's value to contain the ``=`` character
- add unit test cases