### PR TITLE
build: remove downloading of credentials

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,11 @@ environment:
         secure: gevsMhy8RTWMdf7MjOnIo5QaN6JpL9DPK6I+Go5ByZir5LDwyFsv9hO6nBjGTg8n #pragma: whitelist secret
     GITHUB_TOKEN:
         secure: +B2bs86RVtJtlbkB+cTf9bkqnNlFJi/PbBBPzR5jlUlLLZoOc+ZgqgQLwee4tCT+ #pragma: whitelist secret
+    nodejs_version: 12.13.0
+    
 install:
 # Get the latest stable version of Node.js or io.js
-- ps: Install-Product node 12.13.0
+- ps: Install-Product node $env:nodejs_version
 
 - cmd: >-
     pip install git+git://github.com/smsearcy/bumpversion.git@issue-135

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
         secure: gevsMhy8RTWMdf7MjOnIo5QaN6JpL9DPK6I+Go5ByZir5LDwyFsv9hO6nBjGTg8n #pragma: whitelist secret
     GITHUB_TOKEN:
         secure: +B2bs86RVtJtlbkB+cTf9bkqnNlFJi/PbBBPzR5jlUlLLZoOc+ZgqgQLwee4tCT+ #pragma: whitelist secret
-        nodejs_version: 12.13.0
+    nodejs_version: 12.13.0
     
 install:
 # Get the latest stable version of Node.js or io.js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
         secure: +B2bs86RVtJtlbkB+cTf9bkqnNlFJi/PbBBPzR5jlUlLLZoOc+ZgqgQLwee4tCT+ #pragma: whitelist secret
 install:
 # Get the latest stable version of Node.js or io.js
-- ps: Install-Product node $env:nodejs_version
+- ps: Install-Product node 12.13.0
 
 - cmd: >-
     pip install git+git://github.com/smsearcy/bumpversion.git@issue-135

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
         secure: gevsMhy8RTWMdf7MjOnIo5QaN6JpL9DPK6I+Go5ByZir5LDwyFsv9hO6nBjGTg8n #pragma: whitelist secret
     GITHUB_TOKEN:
         secure: +B2bs86RVtJtlbkB+cTf9bkqnNlFJi/PbBBPzR5jlUlLLZoOc+ZgqgQLwee4tCT+ #pragma: whitelist secret
-    nodejs_version: 12.13.0
+        nodejs_version: 12.13.0
     
 install:
 # Get the latest stable version of Node.js or io.js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,16 +46,6 @@ install:
 
 before_build:
 - ps: >-
-    if($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)
-
-    {
-
-      git clone https://$env:CREDENTIALS_GITHUB_TOKEN@github.ibm.com/germanatt/sdk-credentials.git C:\projects\sdk-credentials
-
-    }
-
-    $env:IBM_CREDENTIALS_FILE = "C:\projects\sdk-credentials\ibm-credentials.env"
-
     dotnet restore
 
 build:


### PR DESCRIPTION
This pull request removes downloading of internal watson service credentials in the core build process.